### PR TITLE
Fix (for touchscreens) - Subtitle button

### DIFF
--- a/1080i/VideoOSD.xml
+++ b/1080i/VideoOSD.xml
@@ -273,8 +273,8 @@
                     <width>100</width>
                     <height>64</height>
                     <font>IconMedium</font>
-                    <onclick>Dialog.Close(VideoOSD)</onclick>
-                    <onclick>ActivateWindow(SubtitleSearch)</onclick>
+                    <!--onclick>Dialog.Close(VideoOSD)</onclick-->
+                    <!--onclick>ActivateWindow(SubtitleSearch)</onclick-->
                     <visible>!VideoPlayer.Content(livetv)</visible>
                 </control>
                 <control type="button" id="718">


### PR DESCRIPTION
Pressing the subtitle button on the OSD should not open the subtitle finder, it should at first open the subtitles menu/dropdown, providing options to timeshift subtitles, turn them on/off OR download them. Without this fix it is more or less impossible to access these functions on touchscreen displays. Commented two lines out, tested!

![IMG_20191213_090450](https://user-images.githubusercontent.com/43998058/70777132-a12b9580-1d87-11ea-92bd-d3ad8763e67a.jpg)